### PR TITLE
Remove hardcoded paths from mast/Makefile.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,10 @@ Without a prelude, Typhon doesn't do much. Most Monte applications have a
 reasonable expectation of certain non-kernel features, which are implemented
 in Monte via a prelude and library.
 
-Edit ``mast/Makefile`` to point ``MONTE`` to the location of your `reference
-Monte`_ checkout, and ``MONTE_VENV`` to the virtualenv in which you've
-installed Monte's ``requirements.txt``. 
+``mast/Makefile`` assumes that ``monte`` and ``python`` are on your PATH,
+and that the ``python`` binary references the one in which you installed
+Monte's ``requirements.txt``. The easiest way to do this is to make sure
+that the ``bin`` directory of Monte's virtualenv comes early in your PATH.
 
 To build the MAST library::
 

--- a/mast/Makefile
+++ b/mast/Makefile
@@ -1,6 +1,3 @@
-MONTE = ~/repos/monte/monte
-MONTE_VENV = ~/repos/monte/monte/v
-
 all: lib/atoi.ty lib/bytes.ty lib/enum.ty lib/netstring.ty \
 	lib/regex.ty lib/words.ty \
 	lib/percent.ty \
@@ -18,7 +15,7 @@ all: lib/atoi.ty lib/bytes.ty lib/enum.ty lib/netstring.ty \
 	tubes \
 	games \
 	bench \
-        monte
+	monte
 
 prelude: prelude.ty prelude/brand.ty prelude/region.ty prelude/simple.ty \
 	prelude/space.ty
@@ -51,7 +48,7 @@ monte: lib/monte/monte_ast.ty lib/monte/monte_lexer.ty \
 	lib/monte/termParser.ty
 
 %.ty: %.mt
-	$(MONTE_VENV)/bin/python $(MONTE)/bin/monte -c $< > $@
+	monte -c $< > $@
 
-clean: 
+clean:
 	find -iname \*.ty -delete


### PR DESCRIPTION
This makes the assumption that the `python` and `monte` binaries are
available on $PATH and that the binaries available are the correct ones.
That is, they are from the right virtualenv and monte checkout,
respectively.