### PR TITLE
Don't use "rt" for Darwin, ref #96

### DIFF
--- a/typhon/ruv.py
+++ b/typhon/ruv.py
@@ -67,10 +67,11 @@ def envPaths(name):
         return val.split(':')
 
 
-libs = ["rt", "uv"]
+libs = ["uv"]
 # Issue 96: Darwin: Don't add nsl. ~ C.
+# ...or rt. ~ cdunklau
 if not sys.platform.startswith("darwin"):
-    libs.append("nsl")
+    libs.extend(["nsl", "rt"])
 eci = ExternalCompilationInfo(includes=["uv.h"],
                               include_dirs=envPaths("TYPHON_INCLUDE_PATH"),
                               library_dirs=envPaths("TYPHON_LIBRARY_PATH"),


### PR DESCRIPTION
On OS 10.11.6, I received the following error:

```
[platform:Error] ld: library not found for -lrt
[platform:Error] clang-3.7: error: linker command failed with exit code 1 (use -v to see invocation)
```
Full failing build output is attached:
[darwin-with-rt-build.txt](https://github.com/monte-language/typhon/files/417199/darwin-with-rt-build.txt)

Per @MostAwesomeDude's suggestions, I removed rt from the libs for Darwin, and the build succeeded.