### PR TITLE
Hide nix build dir from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 # Typhon binaries
 mast/**/*.ty
 mast/**/*.mast
+
+# Nix Bits
+result


### PR DESCRIPTION
No need for git to continually say it's not tracking the 'result' directory/link created by Nix.