### PR TITLE
make Guard.supersetOf reflexive

### DIFF
--- a/typhon/objects/guards.py
+++ b/typhon/objects/guards.py
@@ -44,7 +44,7 @@ class Guard(Object):
 
     @method.py("Bool", "Any")
     def supersetOf(self, other):
-        return False
+        return self is other
 
     @method("Str")
     def getDocstring(self):


### PR DESCRIPTION
failing test case:
```
> Bool.supersetOf(Bool)
false
```